### PR TITLE
Ubuntu 12.04.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ on GitHub and report any bugs using the
 ## Installing
 
 **Ubuntu**:
-If you are on Ubuntu 12.04 or later, you can run `install_all.sh` to install
+If you are on Ubuntu 12.04.5 or later, you can run `install_all.sh` to install
 all components (will use ~15G disk space).
 
 **Other operating systems**:
 I suggest installing [VirtualBox](https://www.virtualbox.org/) and running
-Ubuntu 12.04 as a virtual machine.  There's a lot of components and it would be
+Ubuntu 12.04.5 as a virtual machine.  There's a lot of components and it would be
 difficult to port to other operating systems.
 
 For other Linux distributions, you can probably get it to run by rewriting all

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Build the docs (vieable publicly at http://SERVER_NAME/docs).
+# Build the docs (viewable publicly at http://SERVER_NAME/docs).
 #
 # You can view them in docs/_build/html/
 #

--- a/scripts/config_template.sh
+++ b/scripts/config_template.sh
@@ -72,7 +72,7 @@ DATA_DIR=$REPO_DIR/data
 # scripts/restore_database.sh.
 BACKUP_DIR=$REPO_DIR/backup
 
-# This file contains the most recent backup, and is is the version restored by
+# This file contains the most recent backup, and is the version restored by
 # ./restore_database.sh.
 PSQL_DUMP_FILE=$BACKUP_DIR/pg_dump.sql.gz
 

--- a/scripts/install/install_python.sh
+++ b/scripts/install/install_python.sh
@@ -37,7 +37,7 @@ source "$VENV_DIR/bin/activate"
 echo "Installing pip 1.5 locally..."
 mkdir -p opt/pip
 cd opt/pip
-wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py -O get-pip.py
+wget https://bootstrap.pypa.io/get-pip.py -O get-pip.py
 python get-pip.py
 pip install 'pip>=1.5,<1.6'
 cd "$REPO_DIR"

--- a/scripts/install/install_python.sh
+++ b/scripts/install/install_python.sh
@@ -149,6 +149,16 @@ git fetch --all
 git reset --hard r54
 cd "$REPO_DIR"
 
+# install django-endless-pagination (it has been removed from pip)
+echo ""
+echo "Downloading django-endless-pagination"
+[[ -d opt/django-endless-pagination ]] || git clone https://github.com/frankban/django-endless-pagination.git opt/django-endless-pagination
+cd opt/django-endless-pagination
+git fetch --all
+git reset --hard v1.1
+python setup.py install
+cd "$REPO_DIR"
+
 # unfortunately, something downgrades our installation of celery, so we need to
 # re-upgrade it here (function defined above)
 _install_python_packages

--- a/scripts/install/install_python.sh
+++ b/scripts/install/install_python.sh
@@ -47,19 +47,16 @@ pip install --upgrade setuptools
 pip install --upgrade distribute
 pip install --upgrade versiontools
 
-python -m pip list | grep 'PIL (1.1.7)' &> /dev/null
-if [[ $? -ne 0 ]]; then
-	# PIL 1.1.7 from source (it is not available in pip)
-	echo "Installing PIL 1.1.7 locally..."
-	mkdir -p opt/PIL
-	cd opt/PIL
-	wget http://effbot.org/downloads/Imaging-1.1.7.tar.gz
-	tar xvf Imaging-1.1.7.tar.gz
-	cd Imaging-1.1.7/
-	python setup.py build
-	python setup.py install
-	cd "$REPO_DIR"
-fi
+# PIL 1.1.7 from source (it is not available in pip)
+echo "Installing PIL 1.1.7 locally..."
+mkdir -p opt/PIL
+cd opt/PIL
+wget http://effbot.org/downloads/Imaging-1.1.7.tar.gz
+tar xvf Imaging-1.1.7.tar.gz
+cd Imaging-1.1.7/
+python setup.py build
+python setup.py install
+cd "$REPO_DIR"
 
 _install_python_packages() {
 	echo "Installing python packages (locally) in a particular order..."

--- a/scripts/install/install_python.sh
+++ b/scripts/install/install_python.sh
@@ -47,6 +47,20 @@ pip install --upgrade setuptools
 pip install --upgrade distribute
 pip install --upgrade versiontools
 
+python -m pip list | grep 'PIL (1.1.7)' &> /dev/null
+if [[ $? -ne 0 ]]; then
+	# PIL 1.1.7 from source (it is not available in pip)
+	echo "Installing PIL 1.1.7 locally..."
+	mkdir -p opt/PIL
+	cd opt/PIL
+	wget http://effbot.org/downloads/Imaging-1.1.7.tar.gz
+	tar xvf Imaging-1.1.7.tar.gz
+	cd Imaging-1.1.7/
+	python setup.py build
+	python setup.py install
+	cd "$REPO_DIR"
+fi
+
 _install_python_packages() {
 	echo "Installing python packages (locally) in a particular order..."
 	for f in $(ls -1 $DIR/install/requirements-python-*.txt | sort); do

--- a/scripts/install/requirements-python-0.txt
+++ b/scripts/install/requirements-python-0.txt
@@ -46,7 +46,6 @@ south>=0.8.4,<2.0
 gunicorn>=18.0,<19
 django-appconf>=0.6,<0.7
 django-compressor>=1.3,<1.4
-django-endless-pagination>=1.1,<1.2
 django-cacheback>=0.6,<0.7
 django-user-accounts==1.0b7
 django-admin-tools>=0.5.1,<0.6

--- a/scripts/install/requirements-python-0.txt
+++ b/scripts/install/requirements-python-0.txt
@@ -9,7 +9,7 @@ distribute>=0.7.3
 args>=0.1.0,<0.2
 setproctitle>=1.1.8,<1.2
 pyinotify>=0.9.4,<1.0
-ipython>=1.1.0
+ipython>=1.1.0,<1.2
 pytz>=2013
 PIL>=1.1.7,<1.2
 

--- a/scripts/install/requirements-python-0.txt
+++ b/scripts/install/requirements-python-0.txt
@@ -25,7 +25,7 @@ requests>=2.3.0,<2.4
 
 # sphinx docs
 docutils>=0.10,<1.0
-sphinx>=1.2,<2.0
+sphinx>=1.2,<1.4
 sphinx_rtd_theme>=0.1.5,<1.2
 pygments>=1.4,<2.0
 sphinxcontrib-email>=0.1,<0.2


### PR DESCRIPTION
Hi Sean,

The install scripts were not working on a fresh install of Ubuntu 12.04.5 so I fixed them.

- install PIL from source because it is no longer available on pip
- ditto for django-endless-pagination
- update get-pip.py URL (which is pointless since a new virtualenv gets pip)
- pip version requirements for sphinx and ipython were too loose and newer versions were failing.
- fixed a couple of typos I encountered