### PR TITLE
Fixinstall2

### DIFF
--- a/scripts/install/install_python.sh
+++ b/scripts/install/install_python.sh
@@ -18,10 +18,10 @@ fi
 echo "GLOBAL_PIP=$GLOBAL_PIP"
 
 echo "Upgrading versiontools..."
-$GLOBAL_PIP install --upgrade versiontools
+$GLOBAL_PIP install --index-url=https://pypi.python.org/simple/ --upgrade versiontools
 
 echo "Upgrading virtualenv..."
-$GLOBAL_PIP install --upgrade virtualenv
+$GLOBAL_PIP install --index-url=https://pypi.python.org/simple/ --upgrade virtualenv
 
 if [[ ! -d "$VENV_DIR" ]]; then
 	echo "Create virtualenv (with python2.7)..."

--- a/scripts/install/requirements-python-0.txt
+++ b/scripts/install/requirements-python-0.txt
@@ -63,3 +63,6 @@ django-forms-bootstrap>=2.0.3,<2.1
 cython>=0.19.2,<1.0
 numpy>=1.9.0,<1.10
 scipy>=0.13.2,<0.14
+
+# needed by matplotlib
+tornado<5.0


### PR DESCRIPTION
Once again, the python installer is broken.

* pypi.python.org now requires HTTPS. This breaks the system-level pip in Ubuntu 12.04. The fix for pip version 1.0 is to specify "--index-url=https://pypi.python.org/simple/" when installing a package.

* Matplotlib requires tornado but tornado 5.0+ requires ssl updates in Python 2.7.9. The fix is to install tornado<5.0.