### PR TITLE
select django packages compatible with 1.6.11

### DIFF
--- a/scripts/install/requirements-python-0.txt
+++ b/scripts/install/requirements-python-0.txt
@@ -49,12 +49,12 @@ django-compressor>=1.3,<1.4
 django-cacheback>=0.6,<0.7
 django-user-accounts==1.0b7
 django-admin-tools>=0.5.1,<0.6
-django-debug-toolbar>=1.0.1
+django-debug-toolbar>=1.0.1,<1.4
 django-debug-toolbar-template-timings>=0.5.5,<0.6
 django-dtpanel-htmltidy>=0.1.1,<0.2
 django-memcache-status>=1.1,<1.2
 django-cache-panel>=0.1,<0.2
-django-simple-captcha>=0.4.1
+django-simple-captcha==0.4.5
 django-extensions>=1.3.3,<1.4
 django-storages>=1.1.8,<1.2
 django-forms-bootstrap>=2.0.3,<2.1


### PR DESCRIPTION
The most recent versions of django-debug-toolbar and django-simple-captcha depend on django>=1.7. Fix is to limit versions more tightly in requirements.