### PR TITLE
new scripts: free SSL cert setup, CGAL+triangulate

### DIFF
--- a/scripts/install/install_ssl.sh
+++ b/scripts/install/install_ssl.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Set up SSL cert
+#
+
+# find the scripts directory (note the /..)
+DIR="$( builtin cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+source $DIR/load_config.sh
+cd "$REPO_DIR"
+
+echo ""
+echo "Acquiring an SSL certificate with certbot"
+wget https://dl.eff.org/certbot-auto -O opt/certbot-auto
+cd opt
+chmod a+x certbot-auto
+sudo ./certbot-auto --nginx
+cd "$REPO_DIR"
+CMD="echo 0 0,12 \* \* \* root "$REPO_DIR"/opt/certbot-auto renew > /etc/cron.d/certbot"
+sudo sh -c "$CMD"
+
+echo "$0: done"

--- a/scripts/install/install_triangulate.sh
+++ b/scripts/install/install_triangulate.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Set up triangulate
+#
+
+# find the scripts directory (note the /..)
+DIR="$( builtin cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+source $DIR/load_config.sh
+cd "$REPO_DIR"
+
+echo ""
+echo "Installing cgal from source"
+sudo apt-get install libboost1.48-dev libboost-thread1.48-dev libboost-system1.48-dev libgmp-dev libmpfr-dev
+[[ -d opt/cgal ]] || git clone https://github.com/CGAL/cgal.git opt/cgal
+cd opt/cgal
+git checkout tags/releases/CGAL-4.6.3
+cmake .
+make
+sudo make install
+cd "$REPO_DIR"
+
+echo ""
+echo "Installing triangulate from source"
+sudo apt-get install libboost-filesystem1.48-dev
+cd triangulate
+./build.sh
+cd "$REPO_DIR"
+
+echo "$0: done"


### PR DESCRIPTION
New installation helper scripts:

* install_ssl.sh: run this script after the nginx HTTP site is running on http://www.mydomain.foo. The script will use the EFF certbot to automatically acquire a free SSL certificate and install it to the nginx configuration.

* install_triangulate.sh: run this script to build a version of CGAL compatible with Ubuntu 12.04 and the triangulate tool.