### PR TITLE
2 bug fixes

### DIFF
--- a/server/config/settings_local_template.py
+++ b/server/config/settings_local_template.py
@@ -85,6 +85,9 @@ MTURK_MIN_BALANCE = 10
 # debugging the POST submission.
 MTURK_ACCEPT_SANDBOX_HITS = False
 
+# If True, automatically grant MTurk qualifications
+MTURK_CONFIGURE_QUALIFICATIONS = False
+
 # AWS MTurk keys
 if MTURK_SANDBOX:
     # Sandbox account

--- a/server/normals/utils.py
+++ b/server/normals/utils.py
@@ -121,7 +121,8 @@ def rectify_shape_from_uvnb(shape, rectified_normal, max_dim=None):
     M_ij_to_pq = linalg.inv(M_pq_to_ij)
     M_ij_to_pq /= M_ij_to_pq[2, 2]  # NORMALIZE!
     data = M_ij_to_pq.ravel().tolist()[0]
-    image = open_image(shape.photo.image_orig)
+    photo = shape.photo.__class__.objects.get(id=shape.photo.id)
+    image = open_image(photo.image_orig)
     rectified = image.transform(size=size, method=Image.PERSPECTIVE,
                                 data=data, resample=Image.BICUBIC)
 

--- a/server/photos/management/commands/export_whitebalance_clicks.py
+++ b/server/photos/management/commands/export_whitebalance_clicks.py
@@ -20,7 +20,8 @@ class Command(BaseCommand):
 
         out = []
         for label in progress.bar(qset):
-            pil = open_image(label.photo.image_300)
+            photo = label.photo.__class__.objects.get(id=label.photo.id)
+            pil = open_image(photo.image_300)
             points_list = label.points.split(',')
             for idx in xrange(label.num_points):
                 x = float(points_list[idx * 2]) * pil.size[0]

--- a/server/shapes/tasks.py
+++ b/server/shapes/tasks.py
@@ -19,9 +19,10 @@ from common.utils import save_obj_attr_image, get_content_tuple
 @shared_task
 def fill_in_bbox_task(shape):
     """ Helper to fill in the potentially empty image_bbox field """
-
+.
+    photo = shape.photo.__class__.objects.get(id=shape.photo.id)
     image_bbox = mask_complex_polygon(
-        image=open_image(shape.photo.image_orig),
+        image=open_image(photo.image_orig),
         vertices=shape.vertices,
         triangles=shape.triangles,
         bbox_only=True)

--- a/server/shapes/utils.py
+++ b/server/shapes/utils.py
@@ -409,8 +409,9 @@ def update_shape_image_crop(shape, save=True):
     """ Update the cropped image for a shape """
 
     # compute masked image
+    photo = shape.photo.__class__.objects.get(id=shape.photo.id)
     image_crop, image_bbox = mask_complex_polygon(
-        image=open_image(shape.photo.image_orig),
+        image=open_image(photo.image_orig),
         vertices=shape.vertices,
         triangles=shape.triangles)
 
@@ -426,7 +427,8 @@ def update_shape_image_pbox(shape, padding=0.25, save=True):
     """ Update the pbox image for a shape """
 
     # load image
-    image = open_image(shape.photo.image_orig)
+    photo = shape.photo.__class__.objects.get(id=shape.photo.id)
+    image = open_image(photo.image_orig)
     w, h = image.size
 
     # compute bbox
@@ -677,7 +679,8 @@ def create_shape_image_sample(shape, sample_width=256, sample_height=256):
     if ShapeImageSample.objects.filter(shape=shape).exists():
         return
 
-    image = open_image(shape.photo.image_2048)
+    photo = shape.photo.__class__.objects.get(id=shape.photo.id)
+    image = open_image(photo.image_2048)
     image_width, image_height = image.size
 
     triangles = parse_triangles(shape.triangles)


### PR DESCRIPTION
Hi Sean,

This PR fixes two bugs.

1. MTURK_CONFIGURE_QUALIFICATIONS is missing from settings_local so I added it.

2. When open_image() is called on an image through a related object it throws ValueError with "I/O operation on closed file". For example: ```open_image(shape.photo.image_orig)```. The problem is that Django is supposed to automatically open images, but it does not in this case. I believe this is caused by either a bug in the custom Storage class or Django's imagekit in version 1.6. A straightforward fix is to explicitly fetch the related object. For example: ```photo = shape.photo.__class__.objects.get(shape.photo.id) ; open_image(photo.image_orig)```. I applied this pattern to all cases in the code where a related object is used to open a Photo.image_*.